### PR TITLE
Update UrlCast.php

### DIFF
--- a/src/Casts/UrlCast.php
+++ b/src/Casts/UrlCast.php
@@ -15,6 +15,6 @@ class UrlCast implements CastsAttributes
 
     public function set($model, string $key, $value, array $attributes)
     {
-        return parse_url($value, PHP_URL_PATH) ?? '/';
+        return parse_url((string)$value, PHP_URL_PATH) ?? '/';
     }
 }


### PR DESCRIPTION
```
public function filters(): array
{
    return [
        Text::make('Url'),
        Text::make('Title'),
    ];
}
```

Если добавить поле 'Url' в фильтр, оставить это поле пустым и отравить запрос, то в метод **set** класса **UrlCast** приходит значение **null**, а следовательно такая ошибка при попытке применить фильтрацию:


![image](https://github.com/lee-to/laravel-seo-by-url/assets/118539450/424d572f-fe69-4abf-968b-894c989d457a)
